### PR TITLE
Add Ignore + Chunk Progress Event

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Options include:
   live: false, // keep watching the src and mirror new entries,
   dereference: false, // dereference any symlinks
   equals: fun // optional function to determine if two entries are the same, see below
+  ignore: null // optional function to ignore file paths on src or dest
 }
 ```
 
@@ -49,6 +50,16 @@ function equals (src, dst, cb) {
 
 Per default the equals function will check if mtime is larger on the src entry or if the size is different
 
+The ignore function looks like this:
+
+``` js
+function ignore (file) {
+  // ignore any files with secret in them
+  if (file.indexOf('secret') > -1) return true
+  return false
+}
+```
+
 If you are using a custom fs module (like [graceful-fs](https://github.com/isaacs/node-graceful-fs)) you can pass that in
 with the `src` or `dst` like this:
 
@@ -59,6 +70,10 @@ mirror({name: '/Users/maf/cool-stuff', fs: customFs}, {name: '/Users/maf/cool-st
 #### `progress.on('put', src, dst)`
 
 Emitted when a file/folder is copied from the src to the dst folder.
+
+#### `progress.on('chunk', chunk)`
+
+Emitted when a file chunk is copied from the src to the dst folder.
 
 #### `progress.on('del', dst)`
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ mirror({name: '/Users/maf/cool-stuff', fs: customFs}, {name: '/Users/maf/cool-st
 
 Emitted when a file/folder is copied from the src to the dst folder.
 
-#### `progress.on('chunk', chunk)`
+#### `progress.on('put-data', data)`
 
-Emitted when a file chunk is copied from the src to the dst folder.
+Emitted when a file chunk is read from the src.
 
 #### `progress.on('del', dst)`
 

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function mirror (src, dst, opts, cb) {
         if (!a.stat && b.stat) return del(b, next)
 
         // copy to b
-        if (a.stat && !b.stat) return put(a, b, next)
+        if (!opts.ignore && (a.stat && !b.stat)) return put(a, b, next)
 
         // check if they are the same
         equals(a, b, function (err, same) {

--- a/index.js
+++ b/index.js
@@ -148,16 +148,15 @@ function mirror (src, dst, opts, cb) {
 
     var rs = a.fs.createReadStream(a.name)
     var ws = b.fs.createWriteStream(b.name, {mode: a.stat.mode})
-    var increment = through(function (chunk, enc, cb) {
-      progress.emit('chunk', chunk)
-      cb(null, chunk)
-    })
 
     rs.on('error', onerror)
     ws.on('error', onerror)
     ws.on('finish', cb)
 
-    rs.pipe(increment).pipe(ws)
+    rs.pipe(ws)
+    rs.on('data', function (data) {
+      progress.emit('put-data', data)
+    })
 
     function onerror (err) {
       rs.destroy()

--- a/index.js
+++ b/index.js
@@ -54,11 +54,14 @@ function mirror (src, dst, opts, cb) {
         // skip, not in any folder
         if (!a.stat && !b.stat) return next()
 
+        // ignore
+        if (opts.ignore && (opts.ignore(a.name) || opts.ignore(b.name))) return next()
+
         // del from b
         if (!a.stat && b.stat) return del(b, next)
 
         // copy to b
-        if (!opts.ignore && (a.stat && !b.stat)) return put(a, b, next)
+        if (a.stat && !b.stat) return put(a, b, next)
 
         // check if they are the same
         equals(a, b, function (err, same) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ var watch = require('recursive-watch')
 var fs = require('fs')
 var path = require('path')
 var events = require('events')
-var through = require('through2')
 
 module.exports = mirror
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirror-folder",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Small module to mirror a folder to another folder. Supports live mode as well.",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Small module to mirror a folder to another folder. Supports live mode as well.",
   "main": "index.js",
   "dependencies": {
-    "recursive-watch": "^1.1.1",
-    "through2": "^2.0.3"
+    "recursive-watch": "^1.1.1"
   },
   "devDependencies": {
     "standard": "^9.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirror-folder",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "Small module to mirror a folder to another folder. Supports live mode as well.",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Small module to mirror a folder to another folder. Supports live mode as well.",
   "main": "index.js",
   "dependencies": {
-    "recursive-watch": "^1.1.1"
+    "recursive-watch": "^1.1.1",
+    "through2": "^2.0.3"
   },
   "devDependencies": {
     "standard": "^9.0.2"


### PR DESCRIPTION
Adds:

* `opts.ignore` - function that should return true if `file.name` should be ignored
*  `progress.on('chunk', chunk)` - emits whenever a chunk is copied.

The ignore will ignore anything is src or dest. I think that is the right way, as it'll make sure nothing ignored is deleted on the dest side accidentally.