### PR TITLE
fix bug for mirroring single files

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,8 @@ function mirror (src, dst, opts, cb) {
   return progress
 
   function update (name) {
-    pending.push(name.slice(src.name.length) || path.sep)
+    if (name === src.name) pending.push('') // allow single file src
+    else pending.push(name.slice(src.name.length) || path.sep)
     if (pending.length === 1) kick()
   }
 


### PR DESCRIPTION
Currently single files mirror is not working because a `/` gets appended to the name in `update()`, causing `fs.stat` to fail when `kick()` happens.

Fixes it by checking if name is src before appending `path.sep`. 