### PR TITLE
fix bug in rimraf

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ function mirror (src, dst, opts, cb) {
 
         b.fs.lstat(name, function (err, st) {
           if (err) return cb()
-          rimraf({name: name, stat: st}, loop)
+          rimraf({name: name, stat: st, fs: b.fs}, loop)
         })
       }
     })


### PR DESCRIPTION
Delete errored if more than one file in a dir was deleted, `fs` was undefined in the second pass:

```
    b.fs.readdir(b.name, function (_, list) {
        ^

TypeError: Cannot read property 'readdir' of undefined
```

