### PR TITLE
Change opts.live to opts.watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Small module to mirror a folder to another folder.
 
-Supports live mode as well where it will contintously watch the src folder and mirror new entries as they are created/removed.
+Supports watch mode as well where it will continuously watch the src folder and mirror new entries as they are created/removed.
 
 ```
 npm install mirror-folder
@@ -29,7 +29,7 @@ Options include:
 
 ``` js
 {
-  live: false, // keep watching the src and mirror new entries,
+  watch: false, // keep watching the src and mirror new entries,
   dereference: false, // dereference any symlinks
   equals: fun // optional function to determine if two entries are the same, see below
   ignore: null // optional function to ignore file paths on src or dest
@@ -81,7 +81,7 @@ Emitted when a file/folder is deleted from the dst folder.
 
 #### `progress.on('end')`
 
-Emitted when the mirror ends (not emitted in live mode). The mirror callback is called when this event is emitted as well
+Emitted when the mirror ends (not emitted in watch mode). The mirror callback is called when this event is emitted as well
 
 #### `progress.on('error', err)`
 

--- a/index.js
+++ b/index.js
@@ -24,8 +24,9 @@ function mirror (src, dst, opts, cb) {
   var walking = [src.name]
   var pending = []
   var equals = opts.equals || defaultEquals
+  var doWatch = opts.watch || opts.live // opts.live = 1.0 backwards compat
 
-  if (opts.live) progress.destroy = watch(src.name, onwatch)
+  if (doWatch) progress.destroy = watch(src.name, onwatch)
   walk()
 
   return progress
@@ -85,7 +86,7 @@ function mirror (src, dst, opts, cb) {
     pending.shift()
     if (pending.length) return kick()
 
-    if (!opts.live && !walking.length && waiting) return progress.emit('end')
+    if (!doWatch && !walking.length && waiting) return progress.emit('end')
     walk()
   }
 

--- a/index.js
+++ b/index.js
@@ -24,9 +24,8 @@ function mirror (src, dst, opts, cb) {
   var walking = [src.name]
   var pending = []
   var equals = opts.equals || defaultEquals
-  var doWatch = opts.watch || opts.live // opts.live = 1.0 backwards compat
 
-  if (doWatch) progress.destroy = watch(src.name, onwatch)
+  if (opts.watch) stopWatch = watch(src.name, onwatch)
   walk()
 
   return progress
@@ -81,12 +80,13 @@ function mirror (src, dst, opts, cb) {
   }
 
   function next (err) {
+    if (stopped) return
     if (err) return progress.emit('error', err)
 
     pending.shift()
     if (pending.length) return kick()
 
-    if (!doWatch && !walking.length && waiting) return progress.emit('end')
+    if (!opts.watch && !walking.length && waiting) return progress.emit('end')
     walk()
   }
 


### PR DESCRIPTION
`opts.live` is a bit confusing in dat-node because of the multiple uses for `opts.live`, e.g. you may want to pass archive.live but not watch the directory. 

PR changes `opts.live` to `opts.watch` to make it a bit easier upstream. Still accepts `opts.live` so it backwards compatible.

(Sorry, should have seen this before release!)