### PR TITLE
add pending events and expose queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ Emitted at the end of a write stream (files only).
 
 Emitted when a file/folder is deleted from the dst folder.
 
+#### `progress.on('ignore', src, dst)`
+
+Emitted when a file/folder is ignored (either src or dst).
+
+#### `progress.on('skip', src, dst)`
+
+Emitted when a file/folder is skipped. Either src file already is `equal` to dst file or file does not exist in either place.
+
 #### `progress.on('end')`
 
 Emitted when the mirror ends (not emitted in watch mode). The mirror callback is called when this event is emitted as well
@@ -97,6 +105,10 @@ Emitted when a critical error happens. If you pass a mirror callback you don't n
 #### `progress.destory()`
 
 Stop mirroring files. If using watch mode, close the file watcher.
+
+#### `progress.pending`
+
+Array of items pending to be processed.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ with the `src` or `dst` like this:
 mirror({name: '/Users/maf/cool-stuff', fs: customFs}, {name: '/Users/maf/cool-stuff-mirror', fs: anotherFs})
 ```
 
+#### `progress.on('pending', {name, live})`
+
+Emitted when file/dir added to pending queue.
+
+#### `progress.pending`
+
+Array of items pending to be processed.
+
 #### `progress.on('put', src, dst)`
 
 Emitted when a file/folder is copied from the src to the dst folder.
@@ -105,10 +113,6 @@ Emitted when a critical error happens. If you pass a mirror callback you don't n
 #### `progress.destory()`
 
 Stop mirroring files. If using watch mode, close the file watcher.
-
-#### `progress.pending`
-
-Array of items pending to be processed.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -41,8 +41,8 @@ function mirror (src, dst, opts, cb) {
     var item = {name: name.slice(src.name.length) || path.sep, live: live}
     if (name === src.name) item = {name: '', live: live} // allow single file src (not '/')
 
-    progress.emit('pending', item)
     pending.push(item)
+    progress.emit('pending', item)
     if (pending.length === 1) kick()
   }
 


### PR DESCRIPTION
Adds new events and exposes the pending array:

```js
progress.pending // [] of pending items to process
progress.on('pending', {name, live}) // item added to queue

progress.on('skip', src, dst) // item skipped (already copied or doesn't exist)
progress.on('ignore', src, dst) // item ignored
```
