### PR TITLE
Add an option + tests for keepExtras

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Options include:
   dereference: false, // dereference any symlinks
   equals: fun, // optional function to determine if two entries are the same, see below
   ignore: null, // optional function to ignore file paths on src or dest
-  dryRun: false // emit all events but don't write/del files
+  dryRun: false // emit all events but don't write/del files,
+  keepExtras: false // whether to delete extra files in the destination that are not present in the source
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Options include:
   equals: fun, // optional function to determine if two entries are the same, see below
   ignore: null, // optional function to ignore file paths on src or dest
   dryRun: false // emit all events but don't write/del files,
-  keepExtras: false // whether to delete extra files in the destination that are not present in the source
+  keepExisting: false // whether to delete extra files in the destination that are not present in the source
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -141,7 +141,9 @@ function mirror (src, dst, opts, cb) {
         dst.fs.readdir(dstName, function (err, dstNames) {
           if (err) return next()
 
-          queueFilesToDelete(dstNames)
+          if (!opts.keepExtras) {
+            queueFilesToDelete(dstNames)
+          }
           next()
         })
 

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ function mirror (src, dst, opts, cb) {
         dst.fs.readdir(dstName, function (err, dstNames) {
           if (err) return next()
 
-          if (!opts.keepExtras) {
+          if (!opts.keepExisting) {
             queueFilesToDelete(dstNames)
           }
           next()

--- a/test/index.js
+++ b/test/index.js
@@ -206,12 +206,12 @@ test('delete extra files in dest', function (t) {
   })
 })
 
-test('keep extra files in dest when opts.keepExtras is true', function (t) {
+test('keep extra files in dest when opts.keepExisting is true', function (t) {
   tmp(function (err, dir, cleanup) {
     t.ifError(err, 'error')
     fs.writeFileSync(path.join(dir, 'extra.txt'), 'extra stuff')
 
-    mirror(fixtures, dir, {keepExtras: true}, function (err) {
+    mirror(fixtures, dir, {keepExisting: true}, function (err) {
       t.ifError(err, 'error')
       done()
     })

--- a/test/index.js
+++ b/test/index.js
@@ -205,3 +205,26 @@ test('delete extra files in dest', function (t) {
     }
   })
 })
+
+test('keep extra files in dest when opts.keepExtras is true', function (t) {
+  tmp(function (err, dir, cleanup) {
+    t.ifError(err, 'error')
+    fs.writeFileSync(path.join(dir, 'extra.txt'), 'extra stuff')
+
+    mirror(fixtures, dir, {keepExtras: true}, function (err) {
+      t.ifError(err, 'error')
+      done()
+    })
+
+    function done () {
+      t.ok(fs.statSync(path.join(dir, 'hello.txt')), 'file copied')
+      t.ok(fs.statSync(path.join(dir, 'dir', 'file.txt')), 'file copied')
+      t.ok(fs.statSync(path.join(dir, 'extra.txt')), 'extra file kept')
+
+      cleanup(function (err) {
+        t.ifError(err, 'error')
+        t.end()
+      })
+    }
+  })
+})


### PR DESCRIPTION
This adds an option to allow you to keep extra files in the dest dir, rather than delete them all

this was brought up here in dat-download: https://github.com/joehand/dat-download/pull/1