### PR TITLE
fix a minute typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Emitted when the mirror ends (not emitted in watch mode). The mirror callback is
 
 Emitted when a critical error happens. If you pass a mirror callback you don't need to listen for this.
 
-#### `progress.destory()`
+#### `progress.destroy()`
 
 Stop mirroring files. If using watch mode, close the file watcher.
 


### PR DESCRIPTION
changed 'destory' to 'destroy'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mafintosh/mirror-folder/18)
<!-- Reviewable:end -->
