### PR TITLE
Async ignore + ensureParents + custom watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,14 @@ Options include:
 
 ``` js
 {
-  watch: false, // keep watching the src and mirror new entries,
+  watch: false, // keep watching the src and mirror new entries, can also be a custom watch function
   dereference: false, // dereference any symlinks
   equals: fun, // optional function to determine if two entries are the same, see below
-  ignore: null, // optional function to ignore file paths on src or dest
+  ignore: null, // optional async function to ignore file paths on src or dest
   dryRun: false, // emit all events but don't write/del files,
   keepExisting: false, // whether to delete extra files in the destination that are not present in the source
-  skipSpecial: true // skip any files that are not regular files
+  skipSpecial: true // skip any files that are not regular files,
+  ensureParents: false // ensure that all parent directories exist before creating children.
 }
 ```
 
@@ -59,11 +60,16 @@ Per default the equals function will check if mtime is larger on the src entry o
 The ignore function looks like this:
 
 ``` js
-function ignore (file) {
+function ignore (file, cb) {
   // ignore any files with secret in them
-  if (file.indexOf('secret') > -1) return true
-  return false
+  if (file.indexOf('secret') > -1) return process.nextTick(cb, null, true)
+  return process.nextTick(cb, null, false)
 }
+```
+
+If you want to use a custom watch function on the src fs, the `watch` option should take the form:
+```js
+var unwatch = function watch (path, onwatch) { ... }
 ```
 
 If you are using a custom fs module (like [graceful-fs](https://github.com/isaacs/node-graceful-fs)) you can pass that in

--- a/index.js
+++ b/index.js
@@ -81,9 +81,9 @@ function mirror (src, dst, opts, cb) {
         // ignore
         if (opts.ignore) {
           opts.ignore(a.name, a.stat, function (err, aIgnored) {
-            if (err) throw err
+            if (err) return progress.emit('error', err)
             opts.ignore(b.name, b.stat, function (err, bIgnored) {
-              if (err) throw err
+              if (err) return progress.emit('error', err)
               if (aIgnored || bIgnored) {
                 if (live && b.stat && b.stat.isDirectory() && !a.stat) {
                   return rimraf(b, opts.ignore, next)

--- a/index.js
+++ b/index.js
@@ -83,6 +83,7 @@ function mirror (src, dst, opts, cb) {
           opts.ignore(a.name, a.stat, function (err, aIgnored) {
             if (err) throw err
             opts.ignore(b.name, b.stat, function (err, bIgnored) {
+              if (err) throw err
               if (aIgnored || bIgnored) {
                 if (live && b.stat && b.stat.isDirectory() && !a.stat) {
                   return rimraf(b, opts.ignore, next)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "recursive-watch": "^1.1.1"
   },
   "devDependencies": {
-    "hyperdrive": "^8.2.0",
+    "hyperdrive": "beta",
     "random-access-memory": "^2.3.0",
     "standard": "^9.0.2",
     "tape": "^4.6.3",

--- a/test/index.js
+++ b/test/index.js
@@ -289,3 +289,33 @@ test('keep extra files in dest when opts.keepExisting is true', function (t) {
     }
   })
 })
+
+test('ensureParents option works with custom fs', function (t) {
+  var archive = hyperdrive(ram)
+  archive.writeFile('nested/parents/hello.txt', function (err) {
+    t.ifError(err, 'error')
+    tmp(function (err, dir, cleanup) {
+      t.ifError(err, 'error')
+      var puts = 0
+      var progress = mirror({fs: archive, name: '/'}, dir, {
+        ensureParents: true
+      }, function (err) {
+        t.ifError(err, 'error')
+        done()
+      })
+
+      progress.on('put-end', function (src) {
+        puts++
+      })
+
+      function done () {
+        t.same(puts, 1, 'one file added')
+        fs.stat(path.join(dir, 'nested/parents/hello.txt'), function (err, stat) {
+          t.ifError(err, 'error')
+          t.ok(stat)
+          t.end()
+        })
+      }
+    })
+  })
+})


### PR DESCRIPTION
This is a grab bag PR with a few new features:
* The `ignore` option is now an async function
* The `watch` option can now take a custom watch function
* Adds an `ensureParents` option which makes sure that all parent directories exist before creating children (useful if watch updates are unordered).

Think we need to have `watch` and `ensureParents` for the upload/download commands, but we don't need the async ignore if you think that should be removed.